### PR TITLE
Wire frasermolyneux-copilot MCP server (pinned v0.1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,3 +26,9 @@ Terraform-only repository that provisions platform connectivity infrastructure o
 ## Adding a New Private Link Zone
 
 1. Add the zone name to the appropriate environment JSON file in `terraform/private_link_zones/`.
+
+## Org conventions via MCP (when available)
+
+If a `frasermolyneux-copilot` MCP server is configured in your client (`.vscode/mcp.json`, the GitHub Copilot coding-agent MCP config at `.github/copilot/mcp_config.json`, or an equivalent stdio MCP wire-up), **prefer its tools** over your own assumptions when answering questions about org standards, branching, workflows, Terraform, .NET projects, Azure patterns, or shared library / platform consumption contracts. The tool surface is `list_instructions`, `get_instruction`, `search_instructions`, plus the matching `_prompts` and `_agents` equivalents (seven tools total). The catalog source-of-truth lives in `frasermolyneux/.github-copilot` — see `mcp-server/README.md` there for the tool contract.
+
+This is **complementary** to the file-load model: if `./.github-copilot/` is checked out in the runner (per `copilot-setup-steps.yml`), continue to read those files directly. If both are available, prefer MCP for freshness. If no MCP server is configured in your client, treat this section as a no-op and fall back to the file paths above.

--- a/.github/copilot/mcp_config.json
+++ b/.github/copilot/mcp_config.json
@@ -1,0 +1,13 @@
+{
+  "mcpServers": {
+    "frasermolyneux-copilot": {
+      "type": "local",
+      "command": "node",
+      "args": [".github-copilot/mcp-server/dist/index.js"],
+      "env": {
+        "GH_COPILOT_CONTENT_ROOT": ".github-copilot"
+      },
+      "tools": ["*"]
+    }
+  }
+}

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -32,4 +32,14 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: frasermolyneux/.github-copilot
+          ref: refs/tags/v0.1.0
           path: .github-copilot
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20.x
+
+      - name: Build MCP server
+        working-directory: .github-copilot/mcp-server
+        run: npm ci && npm run build

--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ Please read the [contributing](CONTRIBUTING.md) guidance; this is a learning and
 ## Security
 
 Please read the [security](SECURITY.md) guidance; I am always open to security feedback through email or opening an issue.
+
+## Local dev: MCP wire-up
+
+This repo is wired to the org `frasermolyneux-copilot` MCP server, which exposes the shared instruction/prompt/agent catalog from [`frasermolyneux/.github-copilot`](https://github.com/frasermolyneux/.github-copilot) pinned to `v0.1.0`. The coding-agent runner config lives in [`.github/copilot/mcp_config.json`](.github/copilot/mcp_config.json) and is built by [`.github/workflows/copilot-setup-steps.yml`](.github/workflows/copilot-setup-steps.yml). See `.github-copilot/mcp-server/README.md` (in the sibling repo) for the full tool surface, content-root resolution, and per-client wire-up snippets.


### PR DESCRIPTION
Wires this repo into the org `frasermolyneux-copilot` MCP server so the GitHub Copilot coding agent can call the shared instruction/prompt/agent catalog directly, instead of relying on best-effort file reads from a sibling checkout. Mirrors the merged `portal-core` template, pinned to `frasermolyneux/.github-copilot` tag `v0.1.0`.

## What changed

- **`.github/workflows/copilot-setup-steps.yml`** — pinned the existing `frasermolyneux/.github-copilot` checkout to `refs/tags/v0.1.0` (was previously floating on default branch), added `actions/setup-node@v6` (Node 20.x), and a `Build MCP server` step (`npm ci && npm run build` in `.github-copilot/mcp-server`).
- **`.github/copilot/mcp_config.json`** — new file. Registers the stdio server `frasermolyneux-copilot` so the coding-agent runner spawns it from the built `dist/index.js` with `GH_COPILOT_CONTENT_ROOT=.github-copilot`.
- **`.github/copilot-instructions.md`** — appended the canonical `## Org conventions via MCP (when available)` section. Byte-identical to the catalog source-of-truth (SHA256 `DDAC8AA449794730F687EA61759C392D45C6C4E6C7A85C608EF365E15E748F6B`, 1094 chars).
- **`README.md`** — appended a short `## Local dev: MCP wire-up` section pointing at `.github-copilot/mcp-server/README.md` for the full tool surface and per-client wire-up.

## Notes for reviewers

- **No `AGENTS.md` change.** This repo does not have an `AGENTS.md`. The parallel snippet that belongs there is owned by a separate metadata bootstrap pass and is intentionally out of scope here.
- The snippet text in `.github/copilot-instructions.md` is deliberately conditional ("when available") so it is a no-op for any agent/client without an MCP server configured. Don't rephrase it to claim a server "is" wired — the consumer-repo rollout is still in progress across other repos.
- The workflow edit is purely additive plus a pin tightening; no existing step was modified beyond adding the `ref:` line.